### PR TITLE
feat: [#26] TS template for project pages

### DIFF
--- a/src/components/thumbnail/index.ts
+++ b/src/components/thumbnail/index.ts
@@ -16,7 +16,7 @@ export type thumbnailContent = {
 
 //-----------------------------------------------------------------------
 
-export function createThumbnailItem(content: thumbnailContent, showcase: boolean) {
+export function createThumbnail(content: thumbnailContent, showcase: boolean) {
     const itemBox = document.createElement('li');
     const itemThumbnail = document.createElement('img');
     const itemTexts = document.createElement('div');

--- a/src/content/projects/index.ts
+++ b/src/content/projects/index.ts
@@ -2,11 +2,12 @@
 import {projectInfo} from "../../components/vertical-nav/project-nav.ts";
 import {renderView} from "../../views/utils";
 import {renderNavInfo} from "../../components/vertical-nav";
+import {createThumbnail} from "../../components/thumbnail";
 
 import * as nextUx from "./next-ux";
 import * as tank from "./tank";
 import * as spaceCompass from "./space-compass";
-import {createThumbnailItem} from "../../components/thumbnail";
+
 
 const pageReferences: { [key: string]: any } = {
     "next-ux": nextUx,
@@ -34,7 +35,7 @@ export function buildThumbnailList() {
     const list = document.createElement('ul');
 
     Object.values(pageReferences).forEach((page: any) => {
-        const item = createThumbnailItem(page.thumbnail, false);
+        const item = createThumbnail(page.thumbnail, false);
         list.appendChild(item);
     });
 

--- a/src/content/projects/voxco-proposal/index.ts
+++ b/src/content/projects/voxco-proposal/index.ts
@@ -1,0 +1,56 @@
+﻿import {ProjectContent} from "../../../views/project-view/";
+import {AboutProject, RelatedLinks} from "../../../components/vertical-nav/project-nav.ts";
+import {thumbnailContent} from "../../../components/thumbnail";
+
+import WEBM_VIDEO from "./assets/voxco-proposal-showcase.webm";
+import MP4_VIDEO from "./assets/voxco-proposal-showcase.mp4";
+
+import SCREENSHOT_1 from "./assets/voxco-proposal-screenshot-1.jpg"
+import SCREENSHOT_2 from "./assets/voxco-proposal-screenshot-2.jpg"
+import SCREENSHOT_3 from "./assets/voxco-proposal-screenshot-3.jpg"
+import SCREENSHOT_4 from "./assets/voxco-proposal-screenshot-4.jpg"
+
+import THUMBNAIL from "./assets/voxco-proposal-thumbnail.jpg";
+
+export const content: ProjectContent = {
+    name: "INSERT",
+    tagline: "INSERT",
+    path: "INSERT",
+
+    paragraphs: [
+        "INSERT",
+        "INSERT"
+    ],
+
+    heroVideo: [
+        WEBM_VIDEO,
+        MP4_VIDEO
+    ],
+
+    imageGallery: [
+        SCREENSHOT_1,
+        SCREENSHOT_2,
+        SCREENSHOT_3,
+        SCREENSHOT_4
+    ]
+}
+
+export const aboutInfo: AboutProject = {
+    release: "INSERT",
+    platforms: "INSERT",
+    developer: "INSERT"
+}
+
+export const relatedLinksInfo: RelatedLinks[] = [
+    ["INSERT", "INSERT URL"],
+    ["INSERT", "INSERT URL"],
+    ["INSERT", "INSERT URL"]
+]
+
+export const thumbnail: thumbnailContent = {
+    thumbnail: THUMBNAIL,
+    title: content.name,
+    description: "INSERT",
+    tags: ["INSERT", "INSERT"],
+    path: "voxco-proposal"
+}


### PR DESCRIPTION
New template available with Webstorm services. When a new file is created and the template ProjectContent is selected, the user is prompt to insert the page ref of its new content. 

It will be automatically placed in import references.